### PR TITLE
fixed the link going to regex101

### DIFF
--- a/docs/Regex.md
+++ b/docs/Regex.md
@@ -42,4 +42,4 @@ Special patterns:
 |`\b`       |Word boundaries (between \w and \W)|
 |`\B`       |Non-word boundaries|
 
-You can try out your regex pattern on websites like [regex101](https://regex101/)
+You can try out your regex pattern on websites like [regex101](https://regex101.com/)

--- a/docs/Regex.md
+++ b/docs/Regex.md
@@ -42,4 +42,4 @@ Special patterns:
 |`\b`       |Word boundaries (between \w and \W)|
 |`\B`       |Non-word boundaries|
 
-You can try out your regex pattern on websites like [https://regex101.com/](regex101.com).
+You can try out your regex pattern on websites like [regex101](https://regex101/)


### PR DESCRIPTION
before it went to this https://github.com/Chatterino/chatterino2/wiki now it goes to this http://www.regex101.com