### PR TITLE
Add documentation for list literals

### DIFF
--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -20,7 +20,9 @@ A filter must be a valid expression. An expression is comprised of conditions an
 Evaluating to something other than `True` or `False` will lead to all messages being filtered out.
 
 ### Values
-A value can be an integer (`123`, `5`), a string (`"hello"`, `"this is a string"`), or a variable (`author.name`, `message.length`).
+A value can be an integer (`123`, `5`), a string (`"hello"`, `"this is a string"`), a variable (`author.name`, `message.length`), or a list of values (`{123, "hello", author.name}`).
+
+Lists are surrounded by braces (`{}`) and list items are separated by commas. A list item can be a value (e.g. `"hello"`) or an expression wrapped in parentheses (e.g. `(author.sub_length * message.length)`).
 
 When a filter is evaluated, variables are replaced with the values they represent.
 
@@ -30,6 +32,7 @@ When a filter is evaluated, variables are replaced with the values they represen
 | - | - |
 | Int | `123`, `5` |
 | String | `"Hello there"`, `"Escaped \" quote"` |
+| List | `{"list item", 123} |
 
 ### Operators
 

--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -32,7 +32,7 @@ When a filter is evaluated, variables are replaced with the values they represen
 | - | - |
 | Int | `123`, `5` |
 | String | `"Hello there"`, `"Escaped \" quote"` |
-| List | `{"list item", 123} |
+| List | `{"list item", 123}` |
 
 ### Operators
 


### PR DESCRIPTION
Updates the filters documentation to include information about list literals. 
This should be merged with Chatterino/chatterino2#2103