### PR TITLE
Chatterino.com themed dark-theme

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,16 +1,22 @@
 [data-md-color-scheme="chatterino-dark"] {
-    --md-default-bg-color:               rgb(37, 36, 36);
-
-    --md-default-fg-color: rgb(212, 212, 212);
-    --md-default-fg-color--light: rgb(240, 240, 240);
-    
+    --md-default-bg-color: rgb(37, 36, 36);
+    --md-code-bg-color: rgb(47, 45, 45);
+    --md-code-fg-color: rgb(212, 212, 212);
+    --md-default-fg-color: rgb(240, 240, 240);
+    --md-default-fg-color--light: rgb(180, 180, 180);
     --md-typeset-a-color: rgb(96, 165, 250);
-
-    --md-primary-fg-color:               rgb(37, 36, 36);
-    --md-primary-fg-color--light:       rgb(242, 242, 242);
-  
-    --md-accent-fg-color:                rgb(96, 165, 250);
-
+    --md-primary-fg-color: rgb(37, 36, 36);
+    --md-primary-fg-color--light: rgb(242, 242, 242);
+    --md-accent-fg-color: rgb(96, 165, 250);
     --md-footer-bg-color: rgb(26, 25, 25);
     --md-footer-bg-color--dark: rgb(26, 25, 25);
+}
+
+[data-md-color-scheme="chatterino-dark"] .md-typeset table:not([class]) {
+    background-color: var(--md-code-bg-color);
+}
+
+[data-md-color-scheme="chatterino-dark"] .md-typeset table:not([class]) thead th {
+    background-color: var(--md-footer-bg-color);
+    color: var(--md-code-fg-color);
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,16 @@
+[data-md-color-scheme="chatterino-dark"] {
+    --md-default-bg-color:               rgb(37, 36, 36);
+
+    --md-default-fg-color: rgb(212, 212, 212);
+    --md-default-fg-color--light: rgb(240, 240, 240);
+    
+    --md-typeset-a-color: rgb(96, 165, 250);
+
+    --md-primary-fg-color:               rgb(37, 36, 36);
+    --md-primary-fg-color--light:       rgb(242, 242, 242);
+  
+    --md-accent-fg-color:                rgb(96, 165, 250);
+
+    --md-footer-bg-color: rgb(26, 25, 25);
+    --md-footer-bg-color--dark: rgb(26, 25, 25);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: Chatterino
+extra_css:
+  - stylesheets/extra.css
 theme:
   name: material
   logo: https://chatterino.com/img/icon-256.png
@@ -10,7 +12,7 @@ theme:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
-      scheme: slate
+      scheme: chatterino-dark
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode


### PR DESCRIPTION
- Move away from slate theme
- Use colors from new.chatterino.com to create a chatterino-dark theme
- Not all colors that mkdocs has might be covered, so in future more might have to be styled. Only the current elements from the docs are styled


![image](https://user-images.githubusercontent.com/9765622/115125776-aaa3be00-9fca-11eb-89b0-87db1589f90d.png)


I also wanted to somehow combine the sites wiki + chatterino.com but found no good way of adding something in the header bar. 