### PR TITLE
Remove `fallback_to_build_date` option

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,6 @@ plugins:
   - search
   - git-revision-date-localized:
       type: datetime
-      fallback_to_build_date: true
 repo_url: https://github.com/chatterino/chatterino2
 edit_uri: ""
 markdown_extensions:


### PR DESCRIPTION
Accord to [the docs](https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#revision-date-localized), `fallback_to_build_date` is only required when using `mkdocs build` outside the git repo. In this case, we're building with the repo and therefore it isn't needed.