### PR TITLE
Fix literal | character for OR in regex tutorial

### DIFF
--- a/docs/Regex.md
+++ b/docs/Regex.md
@@ -12,7 +12,7 @@ Basic patterns:
 |`x+`       |`x`, repeated any number of times but at least 1|
 |`^`        |The start of the text|
 |`$`        |The end of the text|
-|`x\|y`      |`x` or `y`|
+|`x|y`      |`x` or `y`|
 
 You can group multiple statements with `()`:
 


### PR DESCRIPTION
`x\|y` matches `x|y` literally while `x|y` matches `x` or `y`.
It ain't much, but it's honest work.