### PR TITLE
Update Moderation.md `msg-id` docs to have backwards support for 2.3.4 stable

### DIFF
--- a/docs/Moderation.md
+++ b/docs/Moderation.md
@@ -15,14 +15,14 @@ Moderators are able to log all the channels they are in using the logging featur
 ![Logging](./images/moderation/logging.png)
 
 ## Moderation Mode
-Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/modModeDisabled.png){: width=18; height=18 } in a channel that you moderate. Available variables are `{user.name}`, `{msg.id}` & `{channel.name}`. Below is a list of examples that can be used:
+Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/modModeDisabled.png){: width=18; height=18 } in a channel that you moderate. Available variables are `{user.name}`, `{msg-id}` & `{channel.name}`. Below is a list of examples that can be used:
 
 | Function | Action |
 | - | - |
 | Ban a user | `/ban {user.name}` |
 | Unban a user | `/unban {user.name}` |
 | Timeout a user | `/timeout {user.name} 600` |
-| Delete a user's message | `/delete {msg.id}` |
+| Delete a user's message | `/delete {msg-id}` |
 | pajbot2 report | `/w botname #{channel.name} !report {user.name} being rude` |
 | pajbot2 longreport | `/w botname #{channel.name} !longreport {user.name} being very rude` |
 | Open the user's usercard | `/user {user.name}` |

--- a/docs/Moderation.md
+++ b/docs/Moderation.md
@@ -15,17 +15,18 @@ Moderators are able to log all the channels they are in using the logging featur
 ![Logging](./images/moderation/logging.png)
 
 ## Moderation Mode
-Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/modModeDisabled.png){: width=18; height=18 } in a channel that you moderate. Available variables are `{user.name}`, `{msg-id}` & `{channel.name}`. Below is a list of examples that can be used:
+Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/modModeDisabled.png){: width=18; height=18 } in a channel that you moderate. Available variables are `{user.name}`, `{msg-id}`[¹][note-1] & `{channel.name}`. Below is a list of examples that can be used:
 
 | Function | Action |
 | - | - |
 | Ban a user | `/ban {user.name}` |
 | Unban a user | `/unban {user.name}` |
 | Timeout a user | `/timeout {user.name} 600` |
-| Delete a user's message | `/delete {msg-id}` |
+| Delete a user's message | `/delete {msg-id}`[¹][note-1] |
 | pajbot2 report | `/w botname #{channel.name} !report {user.name} being rude` |
 | pajbot2 longreport | `/w botname #{channel.name} !longreport {user.name} being very rude` |
 | Open the user's usercard | `/user {user.name}` |
+###### As of [nightly][nightly] [9b9fd7d][com1] `{msg.id}` can also be used. <a name="note-1"></a>
 
 ## User Timeout Buttons
 User timeout buttons are very useful while looking at a user's logs. All 8 buttons can be configured to various timeout lengths:
@@ -35,3 +36,6 @@ User timeout buttons are very useful while looking at a user's logs. All 8 butto
 User timeout buttons look like this:
 
 ![UserTimeoutButtons](./images/moderation/userTimeoutButtons.png)
+
+[nightly]: ../Help/#what-is-nightly-and-how-to-use-install-it
+[com1]: https://github.com/Chatterino/chatterino2/commit/9b9fd7d403a0b3bd047ba7134de158c4e2fecbc7

--- a/docs/Moderation.md
+++ b/docs/Moderation.md
@@ -15,19 +15,19 @@ Moderators are able to log all the channels they are in using the logging featur
 ![Logging](./images/moderation/logging.png)
 
 ## Moderation Mode
-Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/modModeDisabled.png){: width=18; height=18 } in a channel that you moderate. Available variables are `{user.name}`, `{msg-id}`[¹](#note-1) & `{channel.name}`. Below is a list of examples that can be used:
+Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/modModeDisabled.png){: width=18; height=18 } in a channel that you moderate. Available variables are `{user.name}`, `{msg-id}`¹ & `{channel.name}`. Below is a list of examples that can be used:
 
 | Function | Action |
 | - | - |
 | Ban a user | `/ban {user.name}` |
 | Unban a user | `/unban {user.name}` |
 | Timeout a user | `/timeout {user.name} 600` |
-| Delete a user's message | `/delete {msg-id}`[¹](#note-1) |
+| Delete a user's message | `/delete {msg-id}`¹ |
 | pajbot2 report | `/w botname #{channel.name} !report {user.name} being rude` |
 | pajbot2 longreport | `/w botname #{channel.name} !longreport {user.name} being very rude` |
 | Open the user's usercard | `/user {user.name}` |
 
-###### As of [nightly][nightly] [9b9fd7d][com1] `{msg.id}` can also be used. <a name="note-1"></a>
+1. As of [nightly][nightly] [9b9fd7d][com1] `{msg.id}` can also be used.
 
 ## User Timeout Buttons
 User timeout buttons are very useful while looking at a user's logs. All 8 buttons can be configured to various timeout lengths:

--- a/docs/Moderation.md
+++ b/docs/Moderation.md
@@ -26,6 +26,7 @@ Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/mo
 | pajbot2 report | `/w botname #{channel.name} !report {user.name} being rude` |
 | pajbot2 longreport | `/w botname #{channel.name} !longreport {user.name} being very rude` |
 | Open the user's usercard | `/user {user.name}` |
+
 ###### As of [nightly][nightly] [9b9fd7d][com1] `{msg.id}` can also be used. <a name="note-1"></a>
 
 ## User Timeout Buttons

--- a/docs/Moderation.md
+++ b/docs/Moderation.md
@@ -15,14 +15,14 @@ Moderators are able to log all the channels they are in using the logging featur
 ![Logging](./images/moderation/logging.png)
 
 ## Moderation Mode
-Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/modModeDisabled.png){: width=18; height=18 } in a channel that you moderate. Available variables are `{user.name}`, `{msg-id}`[¹][note-1] & `{channel.name}`. Below is a list of examples that can be used:
+Moderation mode is enabled by clicking ![ModModeDisabled](./images/moderation/modModeDisabled.png){: width=18; height=18 } in a channel that you moderate. Available variables are `{user.name}`, `{msg-id}`[¹](#note-1) & `{channel.name}`. Below is a list of examples that can be used:
 
 | Function | Action |
 | - | - |
 | Ban a user | `/ban {user.name}` |
 | Unban a user | `/unban {user.name}` |
 | Timeout a user | `/timeout {user.name} 600` |
-| Delete a user's message | `/delete {msg-id}`[¹][note-1] |
+| Delete a user's message | `/delete {msg-id}`[¹](#note-1) |
 | pajbot2 report | `/w botname #{channel.name} !report {user.name} being rude` |
 | pajbot2 longreport | `/w botname #{channel.name} !longreport {user.name} being very rude` |
 | Open the user's usercard | `/user {user.name}` |


### PR DESCRIPTION
In 4cbe7ec197fa0d26aaa508b2e20bc1a57d012e67 we moved our documentation to use `msg.id` on the grounds that `msg-id` is no longer used, while this is true, we still support `msg-id` in the current version. `msg-id` is also the only variation that is supported in stable `2.3.4`.

This PR moves to revert back to `msg-id` and include a note stating that `msg.id` is supported since chatterino/chatterino2@9b9fd7d403a0b3bd047ba7134de158c4e2fecbc7

nitpick: find wording that allows for something to be in-between `nightly` & `9b9fd7d` to separate the links