### PR TITLE
feat: list all built-in commands on Commands page

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -71,6 +71,12 @@ Usage: `/popup [channel]`
 
 Opens the current channel or provided channel's chat in a new window.
 
+### `/r`
+
+Usage: `/r <message>`
+
+Replies to the last received whisper.
+
 ### `/setgame`
 
 Usage: `/setgame <game>`

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -110,7 +110,7 @@ Opens the specified user's Twitch usercard for the given channel (or the channel
 
 ### `/usercard`
 
-Usage: `/user <user> [channel]`
+Usage: `/usercard <user> [channel]`
 
 Opens the specified user's Chatterino usercard for the given channel or the channel provided.
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -8,83 +8,121 @@ Chatterino comes with default commands to perform actions TODO
 
 ### `/block` & `/unblock`
 
-TODO
+Usage: `/(block|unblock) <user>` 
+
+Blocks or unblocks the specified user. Blocking will hide that user's messages/whispers as well as disassociate them from you on Twitch. For more information about blocking, see [Twitch's help article](https://help.twitch.tv/s/article/how-to-manage-harassment-in-chat?language=en_US#BlockWhispersandMessagesfromStrangers).
 
 ### `/chatters`
 
-TODO
+Usage: `/chatters`
+
+Shows the total amount of chatters currently connected to the channel.
 
 ### `/clearmessages`
 
-TODO
+Usage: `/clearmessages`
+
+Clears all messages from the current split/channel. This command is purely visual and is not related to the clearchat moderator command. 
 
 ### `/clip`
 
-TODO
+Usage: `/clip`
+
+Creates a clip from the last 30 seconds of the current channel. Also provides an edit link to edit a clip from the current point in time.
 
 ### `/debug-args`
 
-TODO
+Usage: `/debug-args`
+
+Displays the arguments that chatterino was launched with.
 
 ### `/delete`
 
-TODO
+Usage: `/delete <msg-id>`
+
+Moderator only, deletes a message in chat with the provided ID. Usually used in mod actions as they can pass through the message ID.
 
 ### `/fakemsg`
 
-TODO
+Usage: `/fakemsg <raw message>`
+
+Displays the provided IRC messsage in chat as if it was sent from Twitch's IRC server.
 
 ### `/follow` & `/unfollow`
 
-TODO (removed in v2.3.4)
+TODO: put a description in here with a note about it being removed for people that are confused?
 
 ### `/ignore` & `/uningore`
 
-TODO
+Usage: `/(ignore|unignore) <user>`
+
+Ignores or unignores messages for the specified user on Twitch. Ignoring will hide that user's messages/whispers. For more information about ignoring, see [Twitch's help article](https://help.twitch.tv/s/article/how-to-manage-harassment-in-chat?language=en_US#UseTheIgnoreFeature).
 
 ### `/marker`
 
-TODO
+Usage: `/marker`
+
+Moderator only, creates a [stream marker](https://help.twitch.tv/s/article/creating-highlights-and-stream-markers?language=en_US#markers) in the current stream. Streamer must be live to create markers.
 
 ### `/openurl`
 
-TODO
+Usage: `/openurl`
+
+Opens a URL in the default web browser. Useful in custom commands.
 
 ### `/popout`
 
-TODO
+Usage: `/popout [channel]`
+
+Opens the current channel or provided channel's chat in Twitch's popout webchat, using your default browser.
 
 ### `/popup`
 
-TODO
+Usage: `/popup [channel]`
+
+Opens the current channel or provided channel's chat in a new window.
 
 ### `/setgame`
 
-TODO
+Usage: `/setgame <game>`
+
+Broadcaster only, sets the current channel's game to the best match of the provided game name.
 
 ### `/settitle`
 
-TODO
+Usage: `/settitle <title>`
+
+Broadcaster only, sets the current channel's title to the provided text.
 
 ### `/streamlink`
 
-TODO
+Usage: `/streamlink [channel]`
+
+Attempts to open current or specified stream in streamlink. For more information, see [Streamlink's website](https://streamlink.github.io/).
 
 ### `/uptime`
 
-TODO
+Usage: `/uptime`
+
+Displays the uptime of the current channel's livestream.
 
 ### `/user`
 
-TODO
+Usage: `/user <user> [channel]`
+
+Opens the specified user's Twitch usercard for the given channel (or the channel provided) in the default browser.
 
 ### `/usercard`
 
-TODO
+Usage: `/user <user> [channel]`
 
-### `/w`
+Opens the specified user's Chatterino usercard for the given channel or the channel provided.
 
-TODO
+### `/w (Whisper)`
+
+Usage: `/w <user> <message>`
+
+Whispers the provided text to a user on Twitch. See [Chatterino's whisper FAQ item](https://wiki.chatterino.com/Help/#i-am-unable-to-send-whispers-from-chatterino) for whisper-related issues.
 
 ## Custom commands
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -22,7 +22,7 @@ Shows the total amount of chatters currently connected to the channel.
 
 Usage: `/clearmessages`
 
-Clears all messages from the current split/channel. This command is purely visual and is not related to the clearchat moderator command. 
+Clears all messages from the current split/channel. This command is purely visual and is not related to the `/clear` moderator command. 
 
 ### `/clip`
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -4,7 +4,7 @@ Commands are used as shortcuts for long messages. If a message starts with the "
 
 ## Built-in commands
 
-Chatterino comes with default commands to perform actions TODO
+Chatterino comes with a collection of built-in commands to help with channel management, Twitch interaction, and other misc. features.
 
 ### `/block` & `/unblock`
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -114,7 +114,7 @@ Usage: `/usercard <user> [channel]`
 
 Opens the specified user's Chatterino usercard for the given channel or the channel provided.
 
-### `/w (Whisper)`
+### `/w` (Whisper)
 
 Usage: `/w <user> <message>`
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -58,7 +58,7 @@ Ignores or unignores messages for the specified user on Twitch. Ignoring will hi
 
 Usage: `/marker`
 
-Moderator only, creates a [stream marker](https://help.twitch.tv/s/article/creating-highlights-and-stream-markers?language=en_US#markers) in the current stream. Streamer must be live to create markers.
+[Editor](https://help.twitch.tv/s/article/Managing-Roles-for-your-Channel#types) only, creates a [stream marker](https://help.twitch.tv/s/article/creating-highlights-and-stream-markers?language=en_US#markers) in the current stream. Streamer must be live to create markers.
 
 ### `/openurl`
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -48,10 +48,6 @@ Usage: `/fakemsg <raw message>`
 
 Displays the provided IRC messsage in chat as if it was sent from Twitch's IRC server.
 
-### `/follow` & `/unfollow`
-
-TODO: put a description in here with a note about it being removed for people that are confused?
-
 ### `/ignore` & `/uningore`
 
 Usage: `/(ignore|unignore) <user>`

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -47,6 +47,7 @@ Moderator only, deletes a message in chat with the provided ID. Usually used in 
 Usage: `/fakemsg <raw message>`
 
 Displays the provided IRC messsage in chat as if it was sent from Twitch's IRC server.
+
 ### `/marker`
 
 Usage: `/marker`

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -2,11 +2,17 @@
 
 Commands are used as shortcuts for long messages. If a message starts with the "trigger" then the message will be replaced with the Command.
 
-#### Example
+## Built-in commands
+
+Chatterino comes with default commands to perform actions TODO
+
+## Custom commands
+
+### Example
 
 Add Command `Hello chat :)` with the trigger `/hello`. Now typing `/hello` in chat will send `Hello chat :)` instead of `/hello`.
 
-## Advanced
+### Advanced
 
 - The trigger has to be matched at the **start** of the message but there is a setting to also match them at the **end**.
 - Triggers don't need to start with `/`

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -6,6 +6,86 @@ Commands are used as shortcuts for long messages. If a message starts with the "
 
 Chatterino comes with default commands to perform actions TODO
 
+### `/block` & `/unblock`
+
+TODO
+
+### `/chatters`
+
+TODO
+
+### `/clearmessages`
+
+TODO
+
+### `/clip`
+
+TODO
+
+### `/debug-args`
+
+TODO
+
+### `/delete`
+
+TODO
+
+### `/fakemsg`
+
+TODO
+
+### `/follow` & `/unfollow`
+
+TODO (removed in v2.3.4)
+
+### `/ignore` & `/uningore`
+
+TODO
+
+### `/marker`
+
+TODO
+
+### `/openurl`
+
+TODO
+
+### `/popout`
+
+TODO
+
+### `/popup`
+
+TODO
+
+### `/setgame`
+
+TODO
+
+### `/settitle`
+
+TODO
+
+### `/streamlink`
+
+TODO
+
+### `/uptime`
+
+TODO
+
+### `/user`
+
+TODO
+
+### `/usercard`
+
+TODO
+
+### `/w`
+
+TODO
+
 ## Custom commands
 
 ### Example

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -56,7 +56,7 @@ Usage: `/marker`
 
 ### `/openurl`
 
-Usage: `/openurl`
+Usage: `/openurl <url>`
 
 Opens a URL in the default web browser. Useful in custom commands.
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -47,13 +47,6 @@ Moderator only, deletes a message in chat with the provided ID. Usually used in 
 Usage: `/fakemsg <raw message>`
 
 Displays the provided IRC messsage in chat as if it was sent from Twitch's IRC server.
-
-### `/ignore` & `/uningore`
-
-Usage: `/(ignore|unignore) <user>`
-
-Ignores or unignores messages for the specified user on Twitch. Ignoring will hide that user's messages/whispers. For more information about ignoring, see [Twitch's help article](https://help.twitch.tv/s/article/how-to-manage-harassment-in-chat?language=en_US#UseTheIgnoreFeature).
-
 ### `/marker`
 
 Usage: `/marker`


### PR DESCRIPTION
This PR aims to list and describe all built-in commands in Chatterino. `/follow`/`/unfollow` have been excluded as they no longer work.

Resolves #198 