### PR TITLE
Update `Help` whisper docs post-`friends` deprecation

### DIFF
--- a/docs/Help.md
+++ b/docs/Help.md
@@ -52,7 +52,7 @@ Try closing splits in Chatterino in order to fix this.
 If you are getting the `Your settings prevent you from sending this whisper` error message, it may be due to:
 
 - You turning on the `Block Whispers from Strangers` option in your [Twitch account security settings](https://www.twitch.tv/settings/security).
-- Your account is too new to be able to whisper users using IRC. If you wish to whisper a user, you must first add the user as a friend, then use the Twitch website to whisper the user. This was an IRC spam protection measure put in place by Twitch. This is not a Chatterino bug.
+- Your account is too new to be able to whisper users using IRC. If you wish to whisper a user, you must have that user follow your channel, then use the Twitch website to whisper the user. This was an IRC spam protection measure put in place by Twitch. This is not a Chatterino bug.
 
 ### FFZ/BTTV emotes are not working
 You need to be logged in to see emotes.


### PR DESCRIPTION
Due to the deprecation of `Friends` yesterday, you can no longer add users to your friends list, which means they can no longer be used to bypass Twitch whisper limitations.

Via some testing I did a while back, and re-testing I did earlier, as long as the user you wish to whisper, follows you, you are able to send whispers no matter how new your account is.

Tested with 5 minute old account, and 2012 account

| Attempts | New account follows old account | Old account follows new account | Whisper received |
| ----------  | --- | --- | --- |
| Attempt 1 | ✅ | ❌ | ❌
| Attempt 2 | ✅ | ✅ | ✅
| Attempt 3 | ❌ | ✅ | ✅ 