### PR TITLE
Add an Apple support article for apps from unidentified developers

### DIFF
--- a/docs/Help.md
+++ b/docs/Help.md
@@ -16,7 +16,7 @@ Prior to starting on the below, you should first try the basic troubleshooting s
 - [Windows] Ensure that you have the x64 Visual C++ Redistributables installed **AND** have restarted your PC after installation:
     - x64: <https://aka.ms/vs/16/release/vc_redist.x64.exe>
     - Chocolatey: `choco install vcredist140`
-- [MacOS] Open `System Preferences` go to `Security & Privacy [General Tab]` and select `Open Anyway`.
+- [MacOS] Open `System Preferences` go to `Security & Privacy [General Tab]` and select `Open Anyway` or see this [Apple support article](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac).
 ![mac_help](images/help/macOS_open_anyway.png)
 
 ### I am having an issue with the Chatterino extension


### PR DESCRIPTION
I had a user mention to me that the `Open Anyway` button was missing on macOS Ventura 13.1 - tho the steps in this article are for 13.0, the user confirmed they worked for them.

Even if the missing `Open Anyway` is a one off thing, it doesn't hurt to also link an apple support article for this, also the `Open Anyway` steps are listed at the bottom, so I see no issues with linking to this.