### PR TITLE
Add Syntax Highlighting

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-[data-md-color-scheme="chatterino-dark"] {
+[data-md-color-scheme="slate"] {
     --md-default-bg-color: rgb(37, 36, 36);
     --md-code-bg-color: rgb(47, 45, 45);
     --md-code-fg-color: rgb(212, 212, 212);
@@ -13,11 +13,11 @@
     --md-footer-bg-color--dark: rgb(26, 25, 25);
 }
 
-[data-md-color-scheme="chatterino-dark"] .md-typeset table:not([class]) {
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) {
     background-color: var(--md-code-bg-color);
 }
 
-[data-md-color-scheme="chatterino-dark"] .md-typeset table:not([class]) thead th {
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) thead th {
     background-color: var(--md-footer-bg-color);
     color: var(--md-code-fg-color);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ theme:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
-      scheme: chatterino-dark
+      scheme: slate
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode
@@ -34,6 +34,9 @@ edit_uri: ""
 markdown_extensions:
   - attr_list
   - footnotes
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
   - toc:
       permalink: true
 extra:


### PR DESCRIPTION
Syntax highlighting wasn't enabled, which made it harder to read code in the contribution guidelines.

| Before | After |
|---|---|
| <img src="https://user-images.githubusercontent.com/19953266/211194881-a0f241ed-db17-4b08-ac98-98f951d0e951.png" height="300" /> | <img src="https://user-images.githubusercontent.com/19953266/211194938-683e45b9-7572-483b-90f3-37243947d2b8.png" height="300" /> |

This changes the dark theme's name (to re-use colors defined by `slate`) but doesn't change the appearance.