### PR TITLE
Fix `/banid` appearing as `/banid1` in the table of contents

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -6,9 +6,9 @@ Commands are used as shortcuts for long messages. If a message starts with the "
 
 Chatterino comes with a collection of built-in commands to help with channel management, Twitch interaction, and other misc. features.
 
-### `/banid`[^1]
+### `/banid`
 
-Usage: `/banid <userID>`
+Usage: `/banid <userID>`[^1]
 
 Bans a user by their userID instead of their username. Useful for banning users who are temporarily suspended from Twitch, which `/ban` cannot do anymore.
 


### PR DESCRIPTION
Moved the `[^1]` down to `usage` instead of finding some convoluted way of displaying it.