### PR TITLE
Small Fixes and Corrections for Contribution Guidelines

### DIFF
--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -6,7 +6,7 @@ This is a set of guidelines for contributing to Chatterino. The goal is to teach
 
 ### Formatting
 
-Code is automatically formatted using `clang-format`. It takes the burden off of the programmer and ensures that all contributors use the same style (even if mess something up accidentally). We recommend that you set up automatic formatting on file save in your editor.
+Code is automatically formatted using [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html). It takes the burden off of the programmer and ensures that all contributors use the same style (even if mess something up accidentally). We recommend that you set up automatic formatting on file save in your editor.
 
 ### Comments
 

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -48,7 +48,7 @@ boost::optional<QRegularExpressionMatch> matchLink(const QString &text);
 
 ### Arithmetic Types
 
-Arithmetic types (like char, short, int, long, float and double), bool, and pointers are NOT initialized by default in C++. They keep whatever value is already at their position in the memory. This makes debugging harder and is unpredictable, so we initialize them to zero by using `{}` after their name when declaring them.
+Arithmetic types (like `char`, `int`, `float` or `size_t`), `bool`, and pointers are NOT initialized by default in C++. They keep whatever value is already at their position in the memory. This makes debugging harder and is unpredictable, so we initialize them to zero by using `{}` after their name when declaring them.
 
 ```cpp
 class ArithmeticTypes

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -15,7 +15,7 @@ Comments should only be used to:
 -   Increase readability (e.g. grouping member variables).
 -   Containing information that can't be expressed in code.
 
-Try to structure your code so that comments are not required.
+Try to structure your code, so that comments are not required.
 
 #### Good example
 

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -248,8 +248,8 @@ Keep the element on the stack if possible. If you need a pointer or have complex
 #### QObject classes
 
 -   Use the [object tree](https://doc.qt.io/qt-6/objecttrees.html) to manage lifetime where possible. Objects are destroyed when their parent object is destroyed.
--   If you have to explicitly delete an object use `variable->deleteLater()` instead of `delete variable`. This ensures that it will be deleted on the correct thread.
--   If an object doesn't have a parent consider using `std::unique_ptr<Type, DeleteLater>` with `DeleteLater` from "common/Common.hpp". This will call `deleteLater()` on the pointer once it goes out of scope or the object is destroyed.
+-   If you have to explicitly delete an object use [`variable->deleteLater()`][delete-later] instead of `delete variable`. This ensures that it will be deleted on the correct thread.
+-   If an object doesn't have a parent consider using `std::unique_ptr<Type, DeleteLater>` with `DeleteLater` from "common/Common.hpp". This will call [`deleteLater()`][delete-later] on the pointer once it goes out of scope or the object is destroyed.
 
 [static_cast]: https://en.cppreference.com/w/cpp/language/static_cast
 [const_cast]: https://en.cppreference.com/w/cpp/language/const_cast
@@ -257,3 +257,4 @@ Keep the element on the stack if possible. If you need a pointer or have complex
 [reinterpret_cast]: https://en.cppreference.com/w/cpp/language/reinterpret_cast
 [unique_ptr]: https://en.cppreference.com/w/cpp/memory/unique_ptr
 [shared_ptr]: https://en.cppreference.com/w/cpp/memory/shared_ptr
+[delete-later]: https://doc.qt.io/qt-6/qobject.html#deleteLater

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -17,7 +17,7 @@ Comments should only be used to:
 -   Increase readability (e.g. grouping member variables).
 -   Containing information that can't be expressed in code.
 
-Try to structure your code, so that comments are not required.
+Try to structure your code so that comments are not required.
 
 #### Good example
 

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -247,6 +247,6 @@ Keep the element on the stack if possible. If you need a pointer or have complex
 
 #### QObject classes
 
--   Use the [object tree](https://doc.qt.io/qt-5/objecttrees.html#) to manage lifetime where possible. Objects are destroyed when their parent object is destroyed.
+-   Use the [object tree](https://doc.qt.io/qt-6/objecttrees.html) to manage lifetime where possible. Objects are destroyed when their parent object is destroyed.
 -   If you have to explicitly delete an object use `variable->deleteLater()` instead of `delete variable`. This ensures that it will be deleted on the correct thread.
 -   If an object doesn't have a parent consider using `std::unique_ptr<Type, DeleteLater>` with `DeleteLater` from "src/common/Common.hpp". This will call `deleteLater()` on the pointer once it goes out of scope or the object is destroyed.

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -249,4 +249,4 @@ Keep the element on the stack if possible. If you need a pointer or have complex
 
 -   Use the [object tree](https://doc.qt.io/qt-6/objecttrees.html) to manage lifetime where possible. Objects are destroyed when their parent object is destroyed.
 -   If you have to explicitly delete an object use `variable->deleteLater()` instead of `delete variable`. This ensures that it will be deleted on the correct thread.
--   If an object doesn't have a parent consider using `std::unique_ptr<Type, DeleteLater>` with `DeleteLater` from "src/common/Common.hpp". This will call `deleteLater()` on the pointer once it goes out of scope or the object is destroyed.
+-   If an object doesn't have a parent consider using `std::unique_ptr<Type, DeleteLater>` with `DeleteLater` from "common/Common.hpp". This will call `deleteLater()` on the pointer once it goes out of scope or the object is destroyed.

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -135,7 +135,7 @@ void main() {
 }
 ```
 
-1. `storeLargeObject` accepts an r-value reference and we use `std::move()`, thus we move the object and avoid the need to copy.
+1. `storeLargeObject` accepts an r-value reference and we use [`std::move()`](https://en.cppreference.com/w/cpp/utility/move), thus we move the object and avoid the need to copy.
 2. You can't copy a [`std::unique_ptr`][unique_ptr] so we **need** to move here.
 3. The pointer contained by unique has now been consumed by `storeObject`, so it just holds a null pointer now.
 

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -8,6 +8,8 @@ This is a set of guidelines for contributing to Chatterino. The goal is to teach
 
 Code is automatically formatted using [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html). It takes the burden off of the programmer and ensures that all contributors use the same style (even if mess something up accidentally). We recommend that you set up automatic formatting on file save in your editor.
 
+## Code
+
 ### Comments
 
 Comments should only be used to:

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -75,12 +75,12 @@ class ArithmeticTypes
 5. Other non-arithmetic types call constructors instead, so no need for `{}`.
 6. ⚠ Random value.
 7. ⚠ Random value.
-8. ⚠ Random value. Derefenrencing this will likely segfault.
+8. ⚠ Random value. Dereferencing this will likely segfault.
 9. Unnecessary `{}` as the default constructor will be called even without `{}`.
 
 ### Passing parameters
 
-The way a parameter is passed signals how it is going to be used inside of the function. C++ doesn't have multiple return values so there is "out parameters" (reference to a variable that is going to be assigned inside of the function) to simulate multiple return values.
+The way a parameter is passed signals how it is going to be used inside the function. C++ doesn't have multiple return values, so there is "out parameters" (reference to a variable that is going to be assigned inside the function) to simulate multiple return values.
 
 **Cheap to copy types** like int/enum/etc. can be passed in per value since copying them is fast.
 
@@ -96,15 +96,15 @@ void sendGreeting(const /* (2)! */ User &user /* (3)! */, MessageFlags flags /* 
 
 1. `int`s are cheap to copy. Here, the parameter will likely be passed in a register.
 2. We only need to read the user's name, so it's marked as `const`.
-3. `User` is a class that contains the user's name and other fields, thus it's expensive to copy - so a reference i used.
+3. `User` is a class that contains the user's name and other fields, thus it's expensive to copy - so a reference is used.
 4. `MessageFlags` is an enum, so it's cheap to copy.
 
 **References** mean that the variable doesn't need to be copied when it is passed to a function.
 
-| type               | meaning                                                                                  |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| `const Type& name` | _in_ Parameter. It is NOT going to be modified and may be copied inside of the function. |
-| `Type& name`       | _out_ or _in+out_ Parameter. It will be modified.                                        |
+| type               | meaning                                                                               |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| `const Type& name` | _in_ Parameter. It is NOT going to be modified and may be copied inside the function. |
+| `Type& name`       | _out_ or _in+out_ Parameter. It will be modified.                                     |
 
 **Pointers** signal that objects are managed manually. While the above are only guaranteed to live as long as the function call (= don't store and use later) these may have more complex lifetimes.
 
@@ -135,8 +135,8 @@ void main() {
 }
 ```
 
-1. `storeLargeObject` accepts an r-value reference and we use [`std::move()`](https://en.cppreference.com/w/cpp/utility/move), thus we move the object and avoid the need to copy.
-2. You can't copy a [`std::unique_ptr`][unique_ptr] so we **need** to move here.
+1. `storeLargeObject` accepts an r-value reference, and we use [`std::move()`](https://en.cppreference.com/w/cpp/utility/move), thus we move the object and avoid the need to copy.
+2. You can't copy a [`std::unique_ptr`][unique_ptr], so we **need** to move here.
 3. The pointer contained by unique has now been consumed by `storeObject`, so it just holds a null pointer now.
 
 Generally the lowest level of requirement should be used e.g. passing `Channel&` instead of `std::shared_ptr<Channel>&` (aka `ChannelPtr`) if possible.

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -4,11 +4,11 @@ This is a set of guidelines for contributing to Chatterino. The goal is to teach
 
 ## Tooling
 
-## Formatting
+### Formatting
 
 Code is automatically formatted using `clang-format`. It takes the burden off of the programmer and ensures that all contributors use the same style (even if mess something up accidentally). We recommend that you set up automatic formatting on file save in your editor.
 
-## Comments
+### Comments
 
 Comments should only be used to:
 
@@ -17,7 +17,7 @@ Comments should only be used to:
 
 Try to structure your code so that comments are not required.
 
-##### Good example
+#### Good example
 
 ```cpp
 /**
@@ -29,7 +29,7 @@ int /* (2)! */ compare(const QString &a, const QString &b);
 1. You can't know this from the function signature, so it's good to clarify this.
 2. Even better: Return a "strong ordering" type (but we don't have such a type right now).
 
-##### Bad example
+#### Bad example
 
 ```cpp
 /*
@@ -46,7 +46,7 @@ boost::optional<QRegularExpressionMatch> matchLink(const QString &text);
 
 ## Code
 
-## Arithmetic Types
+### Arithmetic Types
 
 Arithmetic types (like char, short, int, long, float and double), bool, and pointers are NOT initialized by default in C++. They keep whatever value is already at their position in the memory. This makes debugging harder and is unpredictable, so we initialize them to zero by using `{}` after their name when declaring them.
 
@@ -78,7 +78,7 @@ class ArithmeticTypes
 8. ⚠ Random value. Derefenrencing this will likely segfault.
 9. Unnecessary `{}` as the default constructor will be called even without `{}`.
 
-## Passing parameters
+### Passing parameters
 
 The way a parameter is passed signals how it is going to be used inside of the function. C++ doesn't have multiple return values so there is "out parameters" (reference to a variable that is going to be assigned inside of the function) to simulate multiple return values.
 
@@ -141,7 +141,7 @@ void main() {
 
 Generally the lowest level of requirement should be used e.g. passing `Channel&` instead of `std::shared_ptr<Channel>&` (aka `ChannelPtr`) if possible.
 
-## Members
+### Members
 
 All functions names are in `camelCase`. _Private_ member variables are in `camelCase_` (note the underscore at the end). We don't use the `get` prefix for getters. We mark functions as `const` [if applicable](https://stackoverflow.com/questions/751681/meaning-of-const-last-in-a-function-declaration-of-a-class).
 
@@ -174,7 +174,7 @@ void myFreeStandingFunction(); // (7)!
 6. Private methods **don't** have a `_` suffix.
 7. Free standing functions start lowercase as well.
 
-## Casts
+### Casts
 
 -   **Avoid** c-style casts: `(type)variable`.
 -   Instead use explicit type casts: `type(variable)`
@@ -210,7 +210,7 @@ void example(float f, Base *b, const User &user, int p) {
 5. `reinterpret_cast` is required very rarely.
 6. **Avoid** C-style casts.
 
-## This
+### This
 
 Always use `this` to refer to instance members to make it clear where we use either locals or members.
 
@@ -236,16 +236,16 @@ Test::testFunc(int a)
 
 1. It's unclear if it's a local or member variable, especially if the method is more complex.
 
-## Managing resources
+### Managing resources
 
-##### Regular classes
+#### Regular classes
 
 Keep the element on the stack if possible. If you need a pointer or have complex ownership you should use one of these classes:
 
 -   Use `std::unique_ptr` if the resource has a single owner.
 -   Use `std::shared_ptr` if the resource has multiple owners.
 
-##### QObject classes
+#### QObject classes
 
 -   Use the [object tree](https://doc.qt.io/qt-5/objecttrees.html#) to manage lifetime where possible. Objects are destroyed when their parent object is destroyed.
 -   If you have to explicitly delete an object use `variable->deleteLater()` instead of `delete variable`. This ensures that it will be deleted on the correct thread.

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -136,7 +136,7 @@ void main() {
 ```
 
 1. `storeLargeObject` accepts an r-value reference and we use `std::move()`, thus we move the object and avoid the need to copy.
-2. You can't copy a `unique_ptr` so we **need** to move here.
+2. You can't copy a [`std::unique_ptr`][unique_ptr] so we **need** to move here.
 3. The pointer contained by unique has now been consumed by `storeObject`, so it just holds a null pointer now.
 
 Generally the lowest level of requirement should be used e.g. passing `Channel&` instead of `std::shared_ptr<Channel>&` (aka `ChannelPtr`) if possible.
@@ -178,8 +178,8 @@ void myFreeStandingFunction(); // (7)!
 
 -   **Avoid** c-style casts: `(type)variable`.
 -   Instead use explicit type casts: `type(variable)`
--   Or use one of [static_cast](https://en.cppreference.com/w/cpp/language/static_cast), [const_cast](https://en.cppreference.com/w/cpp/language/const_cast) and [dynamic_cast](https://en.cppreference.com/w/cpp/language/dynamic_cast)
--   Try to avoid [reinterpret_cast](https://en.cppreference.com/w/cpp/language/reinterpret_cast) unless necessary.
+-   Or use one of [static_cast], [const_cast] and [dynamic_cast]
+-   Try to avoid [reinterpret_cast] unless necessary.
 
 ```cpp
 void example(float f, Base *b, const User &user, int p) {
@@ -204,10 +204,10 @@ void example(float f, Base *b, const User &user, int p) {
 ```
 
 1. Use explicit type casts.
-2. Use explicit `dynamic_cast`.
-3. Unless extremely obvious, always check the result of `dynamic_cast`.
-4. Only use `const_cast` if using proper const correctness doesn't work.
-5. `reinterpret_cast` is required very rarely.
+2. Use explicit [dynamic_cast].
+3. Unless extremely obvious, always check the result of [dynamic_cast].
+4. Only use [const_cast] if using proper const correctness doesn't work.
+5. [reinterpret_cast] is required very rarely.
 6. **Avoid** C-style casts.
 
 ### This
@@ -242,11 +242,18 @@ Test::testFunc(int a)
 
 Keep the element on the stack if possible. If you need a pointer or have complex ownership you should use one of these classes:
 
--   Use `std::unique_ptr` if the resource has a single owner.
--   Use `std::shared_ptr` if the resource has multiple owners.
+-   Use [`std::unique_ptr`][unique_ptr] if the resource has a single owner.
+-   Use [`std::shared_ptr`][shared_ptr] if the resource has multiple owners.
 
 #### QObject classes
 
 -   Use the [object tree](https://doc.qt.io/qt-6/objecttrees.html) to manage lifetime where possible. Objects are destroyed when their parent object is destroyed.
 -   If you have to explicitly delete an object use `variable->deleteLater()` instead of `delete variable`. This ensures that it will be deleted on the correct thread.
 -   If an object doesn't have a parent consider using `std::unique_ptr<Type, DeleteLater>` with `DeleteLater` from "common/Common.hpp". This will call `deleteLater()` on the pointer once it goes out of scope or the object is destroyed.
+
+[static_cast]: https://en.cppreference.com/w/cpp/language/static_cast
+[const_cast]: https://en.cppreference.com/w/cpp/language/const_cast
+[dynamic_cast]: https://en.cppreference.com/w/cpp/language/dynamic_cast
+[reinterpret_cast]: https://en.cppreference.com/w/cpp/language/reinterpret_cast
+[unique_ptr]: https://en.cppreference.com/w/cpp/memory/unique_ptr
+[shared_ptr]: https://en.cppreference.com/w/cpp/memory/shared_ptr

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -108,9 +108,9 @@ void sendGreeting(const /* (2)! */ User &user /* (3)! */, MessageFlags flags /* 
 
 **Pointers** signal that objects are managed manually. While the above are only guaranteed to live as long as the function call (= don't store and use later) these may have more complex lifetimes.
 
-| type         | meaning                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `Type* name` | The lifetime of the parameter may exceed the length of the function call. It may use the `QObject` parent/children system. |
+| type         | meaning                                                                                                                                                                |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Type* name` | The lifetime of the parameter may exceed the length of the function call. It may use the `QObject` parent/children system (see [_QObject Classes_](#qobject-classes)). |
 
 **R-value references** `&&` work similar to regular references but signal the parameter should be "consumed".
 

--- a/docs/Contributing for Developers.md
+++ b/docs/Contributing for Developers.md
@@ -101,14 +101,14 @@ void sendGreeting(const /* (2)! */ User &user /* (3)! */, MessageFlags flags /* 
 
 **References** mean that the variable doesn't need to be copied when it is passed to a function.
 
-| type               | meaning                                                                               |
+| Type               | Meaning                                                                               |
 | ------------------ | ------------------------------------------------------------------------------------- |
 | `const Type& name` | _in_ Parameter. It is NOT going to be modified and may be copied inside the function. |
 | `Type& name`       | _out_ or _in+out_ Parameter. It will be modified.                                     |
 
 **Pointers** signal that objects are managed manually. While the above are only guaranteed to live as long as the function call (= don't store and use later) these may have more complex lifetimes.
 
-| type         | meaning                                                                                                                                                                |
+| Type         | Meaning                                                                                                                                                                |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Type* name` | The lifetime of the parameter may exceed the length of the function call. It may use the `QObject` parent/children system (see [_QObject Classes_](#qobject-classes)). |
 


### PR DESCRIPTION
* Adds a hierarchy - see the right TOC
* Adds more links
* Fixes small spelling mistakes

It would be really nice if the `CONTIBUTING.md` would point to the wiki (I think this was discussed before), as I think the wiki is easier to read.