### PR TITLE
Remove notes for features added in 2.4.0

### DIFF
--- a/docs/Features.md
+++ b/docs/Features.md
@@ -2,7 +2,7 @@
 
 ## Replies
 
-We support Twitch's [Chat Replies](https://help.twitch.tv/s/article/chat-basics?language=en_US#replies) feature. (Added in 2.4.0)
+We support Twitch's [Chat Replies](https://help.twitch.tv/s/article/chat-basics?language=en_US#replies) feature.
 
 A reply can be executed by right-clicking a message, and selecting `Reply to message`, or by opening an existing Reply Thread and sending your message there.  
 Users who replied to your message, or messages sent in a reply thread you participated in, are highlighted and can be customized in the highlight setting `Participated Reply Threads`.

--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -130,34 +130,34 @@ Please read about the [type rules](#type-rules) to better understand the evaluat
 
 The following variables are available:
 
-| Variable                 | Type         | Description                                                                                            |
-| ------------------------ | ------------ | ------------------------------------------------------------------------------------------------------ |
-| **Author**               |              | User who sent the message                                                                              |
-| `author.badges`          | List<String> | List of author's badges                                                                                |
-| `author.color`           | Color\*      | Color code of author, or none                                                                          |
-| `author.name`            | String       | Display name of author                                                                                 |
-| `author.no_color`        | Bool         | Whether the author has no color set (i.e. gray name)                                                   |
-| `author.subbed`          | Bool         | Whether author is subscribed                                                                           |
-| `author.sub_length`      | Int          | How long author has been subscribed (or zero)                                                          |
-| **Channel**              |              | The channel where the message was sent                                                                 |
-| `channel.name`           | String       | Channel name                                                                                           |
-| `channel.watching`       | Bool         | Whether the channel is being watched (requires Chatterino extension)                                   |
-| `channel.live`           | Bool         | Whether the channel is currently live                                                                  |
-| **Flags**                |              | Message-specific flags                                                                                 |
-| `flags.highlighted`      | Bool         | Whether the message is highlighted                                                                     |
-| `flags.points_redeemed`  | Bool         | Whether the message was redeemed through channel points                                                |
-| `flags.sub_message`      | Bool         | Whether the message is a sub/resub/gift message                                                        |
-| `flags.system_message`   | Bool         | Whether the message is a system message (i.e. timeout/ban/info)                                        |
-| `flags.reward_message`   | Bool         | Whether the message is a redeemed channel point reward message                                         |
-| `flags.first_message`    | Bool         | Whether the message is the author's first message in the channel                                       |
-| `flags.elevated_message` | Bool         | Whether the message is a message the author paid to keep in browser chat for an increased duration     |
-| `flags.cheer_message`    | Bool         | Whether the message includes bits                                                                      |
-| `flags.whisper`          | Bool         | Whether the message is a whisper                                                                       |
-| `flags.reply`            | Bool         | Whether the message is a reply                                                                         |
-| `flags.automod`          | Bool         | Whether the message has automod information or actions                                                 |
-| **Message**              |              | Actual message sent                                                                                    |
-| `message.content`        | String       | Message content                                                                                        |
-| `message.length`         | Int          | Message length                                                                                         |
+| Variable                 | Type         | Description                                                                                        |
+| ------------------------ | ------------ | -------------------------------------------------------------------------------------------------- |
+| **Author**               |              | User who sent the message                                                                          |
+| `author.badges`          | List<String> | List of author's badges                                                                            |
+| `author.color`           | Color\*      | Color code of author, or none                                                                      |
+| `author.name`            | String       | Display name of author                                                                             |
+| `author.no_color`        | Bool         | Whether the author has no color set (i.e. gray name)                                               |
+| `author.subbed`          | Bool         | Whether author is subscribed                                                                       |
+| `author.sub_length`      | Int          | How long author has been subscribed (or zero)                                                      |
+| **Channel**              |              | The channel where the message was sent                                                             |
+| `channel.name`           | String       | Channel name                                                                                       |
+| `channel.watching`       | Bool         | Whether the channel is being watched (requires Chatterino extension)                               |
+| `channel.live`           | Bool         | Whether the channel is currently live                                                              |
+| **Flags**                |              | Message-specific flags                                                                             |
+| `flags.highlighted`      | Bool         | Whether the message is highlighted                                                                 |
+| `flags.points_redeemed`  | Bool         | Whether the message was redeemed through channel points                                            |
+| `flags.sub_message`      | Bool         | Whether the message is a sub/resub/gift message                                                    |
+| `flags.system_message`   | Bool         | Whether the message is a system message (i.e. timeout/ban/info)                                    |
+| `flags.reward_message`   | Bool         | Whether the message is a redeemed channel point reward message                                     |
+| `flags.first_message`    | Bool         | Whether the message is the author's first message in the channel                                   |
+| `flags.elevated_message` | Bool         | Whether the message is a message the author paid to keep in browser chat for an increased duration |
+| `flags.cheer_message`    | Bool         | Whether the message includes bits                                                                  |
+| `flags.whisper`          | Bool         | Whether the message is a whisper                                                                   |
+| `flags.reply`            | Bool         | Whether the message is a reply                                                                     |
+| `flags.automod`          | Bool         | Whether the message has automod information or actions                                             |
+| **Message**              |              | Actual message sent                                                                                |
+| `message.content`        | String       | Message content                                                                                    |
+| `message.length`         | Int          | Message length                                                                                     |
 
 \*Note: To compare a `Color`, compare it to a color hex code string: `author.color == "#FF0000"`
 

--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -150,11 +150,11 @@ The following variables are available:
 | `flags.system_message`   | Bool         | Whether the message is a system message (i.e. timeout/ban/info)                                        |
 | `flags.reward_message`   | Bool         | Whether the message is a redeemed channel point reward message                                         |
 | `flags.first_message`    | Bool         | Whether the message is the author's first message in the channel                                       |
-| `flags.elevated_message` | Bool         | Whether the message is a message the author paid to keep in browser chat for an increased duration[^1] |
-| `flags.cheer_message`    | Bool         | Whether the message includes bits[^1]                                                                  |
+| `flags.elevated_message` | Bool         | Whether the message is a message the author paid to keep in browser chat for an increased duration     |
+| `flags.cheer_message`    | Bool         | Whether the message includes bits                                                                      |
 | `flags.whisper`          | Bool         | Whether the message is a whisper                                                                       |
 | `flags.reply`            | Bool         | Whether the message is a reply                                                                         |
-| `flags.automod`          | Bool         | Whether the message has automod information or actions[^1]                                             |
+| `flags.automod`          | Bool         | Whether the message has automod information or actions                                                 |
 | **Message**              |              | Actual message sent                                                                                    |
 | `message.content`        | String       | Message content                                                                                        |
 | `message.length`         | Int          | Message length                                                                                         |
@@ -221,7 +221,5 @@ The order of operations in filters may not be exactly what you expect.
 -   `a || b && c || d` is evaluated as `a || (b && c) || d`
 
 Basically, if you're unsure about the order of operations, use extra parentheses.
-
-[^1]: Added in 2.4.0
 
 [nightly]: ../Help/#what-is-nightly-and-how-to-use-install-it

--- a/docs/Search.md
+++ b/docs/Search.md
@@ -20,13 +20,13 @@ Starting in 2.4.1 the ability to negate searches is possible. (format `!filter:v
     -   `highlighted` - shows highlighted messages
     -   `system` - shows system messages (grey text ones like: "Now hosting username", "streamer is live", etc.)
     -   `first-msg` - shows a user's first message in the channel
-    -   `elevated-msg` - shows a user's elevated message in the channel (Paid Twitch Feature)[^1]
-    -   `cheer-msg` - shows messages containing bits[^1]
-    -   `redemption` - shows messages that cost the user Twitch channel points[^1]
-    -   `reply` - shows messages sent using the Twitch reply feature[^1]
+    -   `elevated-msg` - shows a user's elevated message in the channel (Paid Twitch Feature)
+    -   `cheer-msg` - shows messages containing bits
+    -   `redemption` - shows messages that cost the user Twitch channel points
+    -   `reply` - shows messages sent using the Twitch reply feature
 -   `regex:<regex>` - shows messages matching a given regex
--   `badge:<value>` - shows messages from users that have a given badge[^1]
--   `subtier:<value>` - shows messages from users that are subscribed at a given tier[^1]
+-   `badge:<value>` - shows messages from users that have a given badge
+-   `subtier:<value>` - shows messages from users that are subscribed at a given tier
 
 ## Examples
 
@@ -89,7 +89,5 @@ Starting in 2.4.1 the ability to negate searches is possible. (format `!filter:v
 
 `!has:link`  
 ![`!has:link`](images/search/example-negate-search-2.png)
-
-[^1]: Added in 2.4.0
 
 [nightly]: ../Help/#what-is-nightly-and-how-to-use-install-it


### PR DESCRIPTION
Removes notes for features added in 2.4.0 - as the next version is on the way and some of these notes are in the way of updating Hype Chat docs. (not really but it seems easier this way)