### PR TITLE
Add more info regarding minidumps and update WinDbg info

### DIFF
--- a/docs/Crash Analysis.md
+++ b/docs/Crash Analysis.md
@@ -4,7 +4,7 @@ When running on Windows, Chatterino 2.4.1 and later will automatically save info
 
 Crashdumps are saved inside the `Crashes/reports` folder in your [Chatterino folder](/Settings/#where-is-my-chatterino-folder-located).
 
-Minidumps contain the stacks of all threads, their state (registers), the exception associated with the crash and some metadata about the CPU and the OS. If you are unsure if your crashdump contains sensitive information, ask a Chatterino developer on the [Discord server](https://discord.gg/qq7DDxjste).
+Minidumps contain the stacks of all threads, their state (registers), the exception associated with the crash, and some metadata about the CPU and the OS. If you are unsure if your crashdump contains sensitive information, ask a Chatterino developer on the [Discord server](https://discord.gg/qq7DDxjste).
 
 There are several ways of analyzing crashes. To get started, you need to have a symbol (PDB) file for your installation. **These files are unique per build** meaning that you need to download the file (this is especially important when using nightly builds). For GitHub builds, you can find the PDB file in the release - it's zipped in an archive ending in `.pdb.7z`. For simplicity, extract the `.pdb` to the location of your `chatterino.exe`.
 

--- a/docs/Crash Analysis.md
+++ b/docs/Crash Analysis.md
@@ -4,11 +4,13 @@ When running on Windows, Chatterino 2.4.1 and later will automatically save info
 
 Crashdumps are saved inside the `Crashes/reports` folder in your [Chatterino folder](/Settings/#where-is-my-chatterino-folder-located).
 
+Minidumps contain the stacks of all threads, their state (registers), the exception associated with the crash and some metadata about the CPU and the OS. If you are unsure if your crashdump contains sensitive information, ask a Chatterino developer on the [Discord server](https://discord.gg/qq7DDxjste).
+
 There are several ways of analyzing crashes. To get started, you need to have a symbol (PDB) file for your installation. **These files are unique per build** meaning that you need to download the file (this is especially important when using nightly builds). For GitHub builds, you can find the PDB file in the release - it's zipped in an archive ending in `.pdb.7z`. For simplicity, extract the `.pdb` to the location of your `chatterino.exe`.
 
 ## WinDbg
 
-For analyzing with a GUI, install [WinDbg Preview](https://apps.microsoft.com/store/detail/windbg-preview/9PGJGD53TN86) from the Microsoft Store. After the installation, you should be able to open the crashdumps (`.dmp` files) right from the Windows Explorer. By default, you won't get much information.
+For analyzing with a GUI, install [WinDbg](https://learn.microsoft.com/windows-hardware/drivers/debugger/). After the installation, you should be able to open the crashdumps (`.dmp` files) right from the Windows Explorer. By default, you won't get much information.
 
 To add names to functions (symbols), open the settings (_Home > Settings_), go to _Debugging Settings_, and add the directory you extracted your symbol file to the _Symbol path_. If there's no `srv*` entry, consider adding one - this will try to load symbols from servers for system libraries.
 


### PR DESCRIPTION
As Chatterino can now restart after a crash and prompts the user with a link to the wiki, I added some information on what is captured in the dump.

WinDbg recently moved on from the -preview version, so I updated the download link.