### PR TITLE
chore: link to edit actions

### DIFF
--- a/docs/Crash Analysis.md
+++ b/docs/Crash Analysis.md
@@ -2,7 +2,7 @@
 
 When running on Windows, Chatterino will automatically save information about a crash in a [minidump](https://docs.sentry.io/platforms/native/guides/minidumps/).
 
-Crashdumps are saved inside the `Crashes/reports` folder in your [Chatterino folder](/Settings/#where-is-my-chatterino-folder-located).
+Crashdumps are saved inside the `Crashes/reports` folder in your [Chatterino folder](./Settings.md/#where-is-my-chatterino-folder-located).
 
 Minidumps contain the stacks of all threads, their state (registers), the exception associated with the crash, and some metadata about the CPU and the OS. If you are unsure if your crashdump contains sensitive information, ask a Chatterino developer on the [Discord server](https://discord.gg/qq7DDxjste).
 

--- a/docs/Help.md
+++ b/docs/Help.md
@@ -134,7 +134,6 @@ This is a Windows issue, it can be mitigated by turning on Compatibility mode fo
 
 ### My Reply was sent to the wrong message
 
-Twitch updated replies to add the functionally we needed to correct this, it was fixed in [5209e47] and the fixed version can be obtained by downloading the latest [nightly][nightly] build.
+Twitch updated replies to add the functionally we needed to correct this, it was fixed in [5209e47] and the fixed version can be obtained by downloading the latest [nightly](#what-is-nightly-and-how-to-use-install-it) build.
 
 [5209e47]: https://github.com/Chatterino/chatterino2/commit/5209e47df18d102925b9d59c79716cab8d89292c
-[nightly]: ../Help/#what-is-nightly-and-how-to-use-install-it

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,8 @@ theme:
     - navigation.instant
     - navigation.sections
     - navigation.top
+    - content.action.edit
+    - content.action.view
     - content.code.annotate
     - content.code.copy
   icon:
@@ -33,7 +35,8 @@ plugins:
       type: datetime
       fallback_to_build_date: true
 repo_url: https://github.com/chatterino/chatterino2
-edit_uri: ""
+repo_name: Chatterino/Chatterino2
+edit_uri: "https://github.com/Chatterino/wiki/edit/master/docs/"
 markdown_extensions:
   - admonition
   - attr_list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,6 @@ plugins:
       type: datetime
       fallback_to_build_date: true
 repo_url: https://github.com/chatterino/chatterino2
-repo_name: Chatterino/Chatterino2
 edit_uri: "https://github.com/Chatterino/wiki/edit/master/docs/"
 markdown_extensions:
   - admonition


### PR DESCRIPTION
The wiki links to the Chatterino2 repo, which is fine. In some cases, however, one wants to make edits to the wiki. Especially people not involved into Chatterino might not know about this repo but still want to make edits.

Because this is such a small PR, I fixed the two warnings about absolute links.