### PR TITLE
Label terms in glossary with color used in image

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -6,23 +6,23 @@ Explain common words used in Chatterino.
 
 ![overview](images/glossary/overview.png)
 
-| Term         | Highlight | Description                                                                                   |
-| ------------ | --------- | --------------------------------------------------------------------------------------------- |
-| Split        | Green     | Includes the chat, input field and a split header                                             |
-| Split Header | Blue      | Contains split title, moderation actions, viewer list, split menu button and add split button |
-| Split Menu   | Red       | Settings or actions for the specific split                                                    |
-| Tab          | Purple    | Can contain multiple splits                                                                   |
+| Term         | Highlight | Description                                                                                    |
+| ------------ | --------- | ---------------------------------------------------------------------------------------------- |
+| Split        | Green     | Includes the chat, input field and a split header.                                             |
+| Split Header | Blue      | Contains split title, moderation actions, viewer list, split menu button and add split button. |
+| Split Menu   | Red       | Settings or actions for the specific split.                                                    |
+| Tab          | Purple    | Can contain multiple splits.                                                                   |
 
 ## Moderation
 
 ![moderation](images/glossary/moderation.png)
 
-| Term                   | Highlight | Description                                                                                                                                                                       |
-| ---------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Moderation buttons     | Red       | Allow you to quickly delete messages, timeout users or execute custom commands. They can be configured in Settings > Moderation > Moderation buttons                              |
-| Moderation mode button | Green     | Toggles whether Moderation buttons are shown                                                                                                                                      |
-| Usercard               | Aqua      | Contains useful information about a user, action buttons as well as their recent messages. Can be opened by clicking someone's username in chat or by typing `/usercard username` |
-| User Timeout Buttons   | Orange    | Allow you time a user out from their Usercard. They can be configured in Settings > Moderation > User Timeout Buttons                                                             |
+| Term                   | Highlight | Description                                                                                                                                                                        |
+| ---------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Moderation buttons     | Red       | Allow you to quickly delete messages, timeout users or execute custom commands. They can be configured in Settings > Moderation > Moderation buttons.                              |
+| Moderation mode button | Green     | Toggles whether Moderation buttons are shown.                                                                                                                                      |
+| Usercard               | Aqua      | Contains useful information about a user, action buttons as well as their recent messages. Can be opened by clicking someone's username in chat or by typing `/usercard username`. |
+| User Timeout Buttons   | Orange    | Allow you time a user out from their Usercard. They can be configured in Settings > Moderation > User Timeout Buttons.                                                             |
 
 ## Replies
 
@@ -33,5 +33,5 @@ Explain common words used in Chatterino.
 | Term          | Highlight | Description                                                                                          |
 | ------------- | --------- | ---------------------------------------------------------------------------------------------------- |
 | Reply Context | Blue      | Contains the message a user was replying to.                                                         |
-| Reply Thread  | Green     | Contains the history of replies to a message that Chatterino has loaded                              |
+| Reply Thread  | Green     | Contains the history of replies to a message that Chatterino has loaded.                             |
 | Reply Input   | Orange    | The input box to send a reply. Available in both the normal Chatterino window, and the Reply Thread. |

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -6,12 +6,17 @@ Explain common words used in Chatterino.
 
 ![overview](images/glossary/overview.png)
 
-| Term         | Highlight | Description                                                                                    |
-| ------------ | --------- | ---------------------------------------------------------------------------------------------- |
-| Split        | Green     | Includes the chat, input field and a split header.                                             |
-| Split Header | Blue      | Contains split title, moderation actions, viewer list, split menu button and add split button. |
-| Split Menu   | Red       | Settings or actions for the specific split.                                                    |
-| Tab          | Purple    | Can contain multiple splits.                                                                   |
+| Term         | Highlight | Description                                                                                                                          |
+| ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Split        | Green     | Includes the chat, input field and a split header.                                                                                   |
+| Split Header | Blue      | Contains split title, chat modes, moderation actions (if mod), viewer list (if mod), split menu button (⋮) and add split button (+). |
+| Split Menu   | Red       | Settings or actions for the specific split.                                                                                          |
+| Tab          | Purple    | Can contain multiple splits.                                                                                                         |
+
+The split title's elements in the Split Header are enabled or disabled in Settings > General > Advanced > Chat title.
+
+[Chat modes](https://safety.twitch.tv/s/article/Chat-Tools#9ChatModes) (e.g. Follower-Only) will only appear in the Split Header if one or more are set. For example, "follow(10m)" means viewers must follow the channel for 10 minutes before they can chat.
+
 
 ## Moderation
 

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -17,7 +17,6 @@ The split title's elements in the Split Header are enabled or disabled in Settin
 
 [Chat modes](https://safety.twitch.tv/s/article/Chat-Tools#9ChatModes) (e.g. Follower-Only) will only appear in the Split Header if one or more are set. For example, "follow(10m)" means viewers must follow the channel for 10 minutes before they can chat.
 
-
 ## Moderation
 
 ![moderation](images/glossary/moderation.png)

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -6,23 +6,23 @@ Explain common words used in Chatterino.
 
 ![overview](images/glossary/overview.png)
 
-| Term         | Description                                                                                   |
-| ------------ | --------------------------------------------------------------------------------------------- |
-| Split        | Includes the chat, input field and a split header                                             |
-| Split Header | Contains split title, moderation actions, viewer list, split menu button and add split button |
-| Split Menu   | Settings or actions for the specific split                                                    |
-| Tab          | Can contain multiple splits                                                                   |
+| Term         | Highlight | Description                                                                                   |
+| ------------ | --------- | --------------------------------------------------------------------------------------------- |
+| Split        | Green     | Includes the chat, input field and a split header                                             |
+| Split Header | Blue      | Contains split title, moderation actions, viewer list, split menu button and add split button |
+| Split Menu   | Red       | Settings or actions for the specific split                                                    |
+| Tab          | Purple    | Can contain multiple splits                                                                   |
 
 ## Moderation
 
 ![moderation](images/glossary/moderation.png)
 
-| Term                   | Description                                                                                                                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Moderation buttons     | Allow you to quickly delete messages, timeout users or execute custom commands. They can be configured in Settings > Moderation > Moderation buttons                              |
-| Moderation mode button | Toggles whether Moderation buttons are shown                                                                                                                                      |
-| Usercard               | Contains useful information about a user, action buttons as well as their recent messages. Can be opened by clicking someone's username in chat or by typing `/usercard username` |
-| User Timeout Buttons   | Allow you time a user out from their Usercard. They can be configured in Settings > Moderation > User Timeout Buttons                                                             |
+| Term                   | Highlight | Description                                                                                                                                                                       |
+| ---------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Moderation buttons     | Red       | Allow you to quickly delete messages, timeout users or execute custom commands. They can be configured in Settings > Moderation > Moderation buttons                              |
+| Moderation mode button | Green     | Toggles whether Moderation buttons are shown                                                                                                                                      |
+| Usercard               | Aqua      | Contains useful information about a user, action buttons as well as their recent messages. Can be opened by clicking someone's username in chat or by typing `/usercard username` |
+| User Timeout Buttons   | Orange    | Allow you time a user out from their Usercard. They can be configured in Settings > Moderation > User Timeout Buttons                                                             |
 
 ## Replies
 
@@ -30,8 +30,8 @@ Explain common words used in Chatterino.
 
 ![reply_popout](images/glossary/reply_popout.png)
 
-| Term          | Description                                                                                          |
-| ------------- | ---------------------------------------------------------------------------------------------------- |
-| Reply Context | Contains the message a user was replying to.                                                         |
-| Reply Thread  | Contains the history of replies to a message that Chatterino has loaded                              |
-| Reply Input   | The input box to send a reply. Available in both the normal Chatterino window, and the Reply Thread. |
+| Term          | Highlight | Description                                                                                          |
+| ------------- | --------- | ---------------------------------------------------------------------------------------------------- |
+| Reply Context | Blue      | Contains the message a user was replying to.                                                         |
+| Reply Thread  | Green     | Contains the history of replies to a message that Chatterino has loaded                              |
+| Reply Input   | Orange    | The input box to send a reply. Available in both the normal Chatterino window, and the Reply Thread. |


### PR DESCRIPTION
Added references to the colours of the boxes used in the images to highlight the element described in the table.

Added information about split title elements and chat modes.
