### PR TITLE
Remove `kappa.lol` from list of image uploaders

### DIFF
--- a/docs/Image Uploader.md
+++ b/docs/Image Uploader.md
@@ -69,16 +69,6 @@ Replace `XXXXXXXXXXXXXXX` with your Base64-encoded user and password
 | Image link    |                                        |
 | Deletion link |                                        |
 
-### [kappa.lol](https://kappa.lol)
-
-| Row           | Description                    |
-| ------------- | ------------------------------ |
-| Request URL   | `https://kappa.lol/api/upload` |
-| Form field    | `file`                         |
-| Extra headers |                                |
-| Image link    | `{link}`                       |
-| Deletion link | `{delete}`                     |
-
 # Unsupported sites
 
 -   `catbox.moe`: It's not possible yet to upload to catbox.moe due to how their upload method is constructed.


### PR DESCRIPTION
As of 2025-06-18 `kappa.lol` won't be hosted anymore.

![image](https://github.com/user-attachments/assets/16ee6527-c092-463f-b0da-687edefa23ab)
