### PR TITLE
fix: make powershell logs example valid for pressing copy button

### DIFF
--- a/docs/Developer Logs.md
+++ b/docs/Developer Logs.md
@@ -15,10 +15,10 @@ Multiple rules can be concatenated with `;`: `chatterino.*.debug=true;chatterino
 <!-- prettier-ignore-start -->
 === ":fontawesome-brands-windows: Windows PowerShell"
     ```pwsh-session
-    > $Env:QT_WIN_DEBUG_CONSOLE="new"
-    > $Env:QT_LOGGING_RULES="chatterino.*.debug=true"
-    > <path-to>/chatterino.exe
-    (a new console window will show)
+    $Env:QT_WIN_DEBUG_CONSOLE="new"
+    $Env:QT_LOGGING_RULES="chatterino.*.debug=true"
+    <path-to>/chatterino.exe
+    # (a new console window will show)
     ```
 === ":fontawesome-brands-windows: Windows CMD"
     ```doscon


### PR DESCRIPTION
when you press the fancy ![image](https://github.com/user-attachments/assets/37c9fd2f-8959-4a4e-9c2d-c980025f3749) button, pasting it into powershell gives you 2 breaking lines
```
The term '<' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the
spelling of the name, or if a path was included, verify that the path is correct and try again.
```

and one non breaking but still angry line `(the info in here)`
```
The term 'a' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the
spelling of the name, or if a path was included, verify that the path is correct and try again.
```

so change this to only require the user to change the path, and not multiple lines


also yes this will conflict the other examples, but cmd doesn't support multi-line the same way powershell does, so it's already wrong enough