### PR TITLE
fix: re-enable code copying

### DIFF
--- a/docs/Developer Logs.md
+++ b/docs/Developer Logs.md
@@ -14,21 +14,21 @@ Multiple rules can be concatenated with `;`: `chatterino.*.debug=true;chatterino
 
 <!-- prettier-ignore-start -->
 === ":fontawesome-brands-windows: Windows PowerShell"
-    ```pwsh-session
+    ``` { .pwsh-session .no-copy }
     > $Env:QT_WIN_DEBUG_CONSOLE="new"
     > $Env:QT_LOGGING_RULES="chatterino.*.debug=true"
     > <path-to>/chatterino.exe
     (a new console window will show)
     ```
 === ":fontawesome-brands-windows: Windows CMD"
-    ```doscon
+    ``` { .doscon .no-copy }
     > set QT_WIN_DEBUG_CONSOLE=new
     > set QT_LOGGING_RULES=chatterino.*.debug=true
     > <path-to>/chatterino.exe
     (a new console window will show)
     ```
 === ":simple-linux:/:simple-apple: Linux/macOS"
-    ```console
+    ``` { .console .no-copy }
     $ export QT_LOGGING_RULES="chatterino.*.debug=true"
     $ <path-to>/chatterino
     chatterino.hotkeys: Try add default "close popup window"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ theme:
     - content.action.edit
     - content.action.view
     - content.code.annotate
+    - content.code.copy
   icon:
     repo: fontawesome/brands/github
 plugins:


### PR DESCRIPTION
...but disable it for the logging examples as described in https://github.com/Chatterino/wiki/pull/462#issuecomment-3263920420.

We already have code examples in the theme and developer documentation where it makes sense to copy code. Let's not break this.