### PR TITLE
Remove deletion link from Image Uploader.md

### DIFF
--- a/docs/Image Uploader.md
+++ b/docs/Image Uploader.md
@@ -44,11 +44,11 @@ Replace `XXXXXXXXXXXXXXX` with your API key from s-ul.eu. It can be found on [yo
 
 Similar to nuuls, this is an anonymous image and video upload tool with a default expiration of 30 days.
 
-| Row           | Description                      |
-| ------------- | -------------------------------- |
-| Request URL   | `https://imgdrip.com/api/upload` |
-| Form field    | `file`                           |
-| Image link    | `{url}`                          |
+| Row         | Description                      |
+| ----------- | -------------------------------- |
+| Request URL | `https://imgdrip.com/api/upload` |
+| Form field  | `file`                           |
+| Image link  | `{url}`                          |
 
 ### [i.fourtf.com](https://github.com/fourtf/i)
 

--- a/docs/Image Uploader.md
+++ b/docs/Image Uploader.md
@@ -49,7 +49,6 @@ Similar to nuuls, this is an anonymous image and video upload tool with a defaul
 | Request URL   | `https://imgdrip.com/api/upload` |
 | Form field    | `file`                           |
 | Image link    | `{url}`                          |
-| Deletion link | `{deleteUrl}`                    |
 
 ### [i.fourtf.com](https://github.com/fourtf/i)
 


### PR DESCRIPTION
Removed deletion link from the Image Uploader documentation. No longer supported by ImgDrip.

- ImgDrip guy