### PR TITLE
feat: placeholders for commands executed on messages

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -164,4 +164,12 @@ Add Command `Hello chat :)` with the trigger `/hello`. Now typing `/hello` in ch
 - `{stream.game}` can be used to insert the game set in the current channel. Only works if the channel is live.  
   Example: Add Command `I'm currently playing {stream.game}` with trigger `/game`. Now typing `/game` will send a message like `I'm currently playing World of Warcraft`.
 
+- `{user.name}` can be used when executing a command on a message to insert the message sender's Twitch username.
+
+- `{msg.id}` can be used when executing a command on a message to insert the message's id.
+
+- `{msg.text}` can be used when executing a command on a message to insert the message's text.
+
+- `{input.text}` can be used when executing a command on a message/with a hotkey to insert the text in the split input.
+
 [nightly]: ../Help/#what-is-nightly-and-how-to-use-install-it


### PR DESCRIPTION
I was trying to remember what the placeholder for message ID was, when i tried to look it up in the wiki i noticed it was missing. I added the other missing placeholders in the same family as well.