### PR TITLE
Use the default token for deploying and specify workflow perms

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           mkdocs build --verbose
 
       - name: Deploy 🚀
-        #if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: gh-pages # The branch the action should deploy to. (gh-pages is the default but I wanted to keep changes minimal)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           mkdocs build --verbose
 
       - name: Deploy 🚀
-        if: github.ref == 'refs/heads/master'
+        #if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: gh-pages # The branch the action should deploy to. (gh-pages is the default but I wanted to keep changes minimal)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,6 +31,5 @@ jobs:
         if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages # The branch the action should deploy to.
+          branch: gh-pages # The branch the action should deploy to. (gh-pages is the default but I wanted to keep changes minimal)
           folder: site # The folder the action should deploy.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,5 +31,5 @@ jobs:
         if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
-          branch: gh-pages # The branch the action should deploy to. (gh-pages is the default but I wanted to keep changes minimal)
+          branch: gh-pages # The branch the action should deploy to.
           folder: site # The folder the action should deploy.


### PR DESCRIPTION
`gh-pages` is already the default for the branch option but I wanted to keep changes minimal (See: https://github.com/JamesIves/github-pages-deploy-action#required-setup)

Test-PR: https://github.com/Wissididom/chatterino-wiki/pull/1