### PR TITLE
Use GitHub Actions as Pages Committer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,3 +33,5 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: site # The folder the action should deploy.
+          git-config-name: "github-actions[bot]"
+          git-config-email: "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
I'm not sure if we want that, but my thinking was that GitHub Actions would be more fitting than the Actor (in this case probably always the person that merges a PR), and it would be easy to see which commits where pushed manually to gh-pages and which came from GH Actions.

This is how it will look like in the commit list:
<img width="474" height="225" alt="Screenshot From 2026-08-27 21-58-23" src="https://github.com/user-attachments/assets/1f245933-2423-444c-8d88-4154630de5d5" />

This screenshot is from some other project of mine.